### PR TITLE
간단한 팀 기능 추가

### DIFF
--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
@@ -1,0 +1,51 @@
+package com.wccg.well_c_code_git_backend.domain.team.controller;
+
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.CreateTeamRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.service.TeamService;
+import com.wccg.well_c_code_git_backend.domain.user.model.User;
+import com.wccg.well_c_code_git_backend.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.wccg.well_c_code_git_backend.domain.team.mapper.TeamMapper.toCreateTeamResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/team")
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @PreAuthorize("hasRole('USER')")
+    @PostMapping("")
+    @Operation(
+            summary = "팀 생성",
+            description = """
+                            **⚠️ 본 API는 JWT 인증이 필요하며, 사용자 권한(`ROLE_USER`)이 요구됩니다.**
+                            
+                            팀을 생성합니다.
+                            - 팀 이름 (중복 불가 / 2자 - 12자)
+                            - 팀 소개 문구
+                            - 팀 프로필 사진
+                            """,
+            security = @SecurityRequirement(name = "JWT")
+    )
+    public ResponseEntity<ApiResponse<CreateTeamResponse>> createTeam(@AuthenticationPrincipal User user, CreateTeamRequest request){
+
+        ServiceCreateTeamResponse serviceResponse = teamService.createTeam(user,request);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(toCreateTeamResponse(serviceResponse),"팀 생성 완료"));
+    }
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
@@ -1,10 +1,15 @@
 package com.wccg.well_c_code_git_backend.domain.team.controller;
 
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.CreateTeamRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.JoinTeamRequestRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.JoinTeamRequestResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceJoinTeamRequestRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.service.TeamService;
 import com.wccg.well_c_code_git_backend.domain.user.model.User;
+import com.wccg.well_c_code_git_backend.domain.user.service.UserService;
 import com.wccg.well_c_code_git_backend.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -14,10 +19,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.wccg.well_c_code_git_backend.domain.team.mapper.TeamMapper.toCreateTeamResponse;
+import static com.wccg.well_c_code_git_backend.domain.team.mapper.TeamMapper.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,6 +31,7 @@ import static com.wccg.well_c_code_git_backend.domain.team.mapper.TeamMapper.toC
 public class TeamController {
 
     private final TeamService teamService;
+    private final UserService userService;
 
     @PreAuthorize("hasRole('USER')")
     @PostMapping("")
@@ -40,12 +47,32 @@ public class TeamController {
                             """,
             security = @SecurityRequirement(name = "JWT")
     )
-    public ResponseEntity<ApiResponse<CreateTeamResponse>> createTeam(@AuthenticationPrincipal User user, CreateTeamRequest request){
+    public ResponseEntity<ApiResponse<CreateTeamResponse>> createTeam(@AuthenticationPrincipal User user, @RequestBody CreateTeamRequest request){
 
         ServiceCreateTeamResponse serviceResponse = teamService.createTeam(user,request);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.ok(toCreateTeamResponse(serviceResponse),"팀 생성 완료"));
+    }
+
+    @PreAuthorize("hasRole('USER')")
+    @PostMapping("/join-request")
+    @Operation(
+            summary = "팀 가입 요청",
+            description = """
+                            **⚠️ 본 API는 JWT 인증이 필요하며, 사용자 권한(`ROLE_USER`)이 요구됩니다.**
+                            
+                            API 설명
+                            """,
+            security = @SecurityRequirement(name = "JWT")
+    )
+    public ResponseEntity<ApiResponse<JoinTeamRequestResponse>> joinTeamRequest(@AuthenticationPrincipal User user, @RequestBody JoinTeamRequestRequest request){
+
+        ServiceJoinTeamRequestResponse serviceResponse = teamService.joinTeamRequest(user,toServiceJoinTeamRequestRequest(request));
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(toJoinTeamRequestResponse(serviceResponse),"팀 가입 요청 완료"));
     }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
@@ -6,6 +6,8 @@ import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.Respo
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.JoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadJoinTeamRequestResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceReadTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceReadJoinTeamRequestResponse;
@@ -111,5 +113,26 @@ public class TeamController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.ok(null, "팀 가입 요청 수락/거절 완료"));
+    }
+
+    @GetMapping("")
+    @Operation(
+            summary = "팀 조회(간단)",
+            description = """
+                            - 팀의 정보를 조회합니다. (스탯 제외 간단 버전)
+                              - 팀 이름
+                              - 팀 소개
+                              - 팀 정보 사진
+                              - 팀 인원 수
+                              - 팀 생성일
+                            """
+    )
+    public ResponseEntity<ApiResponse<ReadTeamResponse>> readTeam(@RequestParam Long teamId){
+
+        ServiceReadTeamResponse serviceResponse = teamService.readTeam(teamId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(toReadTeamResponse(serviceResponse),"팀 조회 완료"));
     }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
@@ -2,6 +2,7 @@ package com.wccg.well_c_code_git_backend.domain.team.controller;
 
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.CreateTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.JoinTeamRequestRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.RespondJoinTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.JoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadJoinTeamRequestResponse;
@@ -93,4 +94,22 @@ public class TeamController {
                 .body(ApiResponse.ok(toReadJoinTeamRequestResponseList(serviceResponseList), "가입 요청 목록 조회 완료"));
     }
 
+    @PreAuthorize("hasRole('USER')")
+    @PatchMapping("/join-request")
+    @Operation(
+            summary = "팀 가입 요청 수락/거절",
+            description = """
+                            **⚠️ 본 API는 JWT 인증이 필요하며, 사용자 권한(`ROLE_USER`)이 요구됩니다.**
+                            - 현재 로그인한 팀의 관리자가 팀 가입 요청을 수락 또는 거절합니다.
+                            """,
+            security = @SecurityRequirement(name = "JWT")
+    )
+    public ResponseEntity<ApiResponse<Void>> respondJoinTeamRequest(@AuthenticationPrincipal User user, @RequestBody RespondJoinTeamRequest request){
+
+        teamService.respondJoinTeamRequest(user,request);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(null, "팀 가입 요청 수락/거절 완료"));
+    }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
@@ -3,14 +3,14 @@ package com.wccg.well_c_code_git_backend.domain.team.controller;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.CreateTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.JoinTeamRequestRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.RespondJoinTeamRequest;
-import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
-import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.JoinTeamRequestResponse;
-import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadJoinTeamRequestResponse;
-import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.UpdateTeamRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.*;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceReadTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceReadJoinTeamRequestResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceUpdateTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.repository.TeamRepository;
 import com.wccg.well_c_code_git_backend.domain.team.service.TeamService;
 import com.wccg.well_c_code_git_backend.domain.user.model.User;
 import com.wccg.well_c_code_git_backend.global.dto.ApiResponse;
@@ -33,6 +33,7 @@ import static com.wccg.well_c_code_git_backend.domain.team.mapper.TeamMapper.*;
 public class TeamController {
 
     private final TeamService teamService;
+    private final TeamRepository teamRepository;
 
     @PreAuthorize("hasRole('USER')")
     @PostMapping("")
@@ -134,5 +135,26 @@ public class TeamController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.ok(toReadTeamResponse(serviceResponse),"팀 조회 완료"));
+    }
+
+    @PreAuthorize("hasRole('USER')")
+    @PatchMapping("")
+    @Operation(
+            summary = "팀 수정",
+            description = """
+                            **⚠️ 본 API는 JWT 인증이 필요하며, 사용자 권한(`ROLE_USER`)이 요구됩니다.**
+                            - 현재 로그인한 팀의 관리자가 팀의 정보를 수정합니다.
+                              - 팀 소개
+                              - 팀 정보 사진
+                            - 팀 이름은 변경 불가
+                            """,
+            security = @SecurityRequirement(name = "JWT")
+    )
+    public ResponseEntity<ApiResponse<UpdateTeamResponse>> updateTeam(@AuthenticationPrincipal User user, @RequestBody UpdateTeamRequest request){
+        ServiceUpdateTeamResponse serviceResponse = teamService.updateTeam(user, toServiceUpdateTeamRequest(request));
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(toUpdateTeamResponse(serviceResponse),"팀 수정 완료"));
     }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/controller/TeamController.java
@@ -4,12 +4,12 @@ import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.Creat
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.JoinTeamRequestRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.JoinTeamRequestResponse;
-import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceJoinTeamRequestRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceJoinTeamRequestResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceReadJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.service.TeamService;
 import com.wccg.well_c_code_git_backend.domain.user.model.User;
-import com.wccg.well_c_code_git_backend.domain.user.service.UserService;
 import com.wccg.well_c_code_git_backend.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -18,10 +18,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.wccg.well_c_code_git_backend.domain.team.mapper.TeamMapper.*;
 
@@ -31,7 +30,6 @@ import static com.wccg.well_c_code_git_backend.domain.team.mapper.TeamMapper.*;
 public class TeamController {
 
     private final TeamService teamService;
-    private final UserService userService;
 
     @PreAuthorize("hasRole('USER')")
     @PostMapping("")
@@ -75,4 +73,24 @@ public class TeamController {
                 .status(HttpStatus.OK)
                 .body(ApiResponse.ok(toJoinTeamRequestResponse(serviceResponse),"팀 가입 요청 완료"));
     }
+
+    @PreAuthorize("hasRole('USER')")
+    @GetMapping("/join-request")
+    @Operation(
+            summary = "팀 가입 요청 목록 조회",
+            description = """
+                            **⚠️ 본 API는 JWT 인증이 필요하며, 사용자 권한(`ROLE_USER`)이 요구됩니다.**
+                            - 현재 로그인한 관리자가 속한 팀의 가입 요청 목록을 조회합니다.
+                            - 가입 요청은 최신순(요청일 기준 내림차순)으로 정렬되어 반환됩니다.
+                            """,
+            security = @SecurityRequirement(name = "JWT")
+    )
+    public ResponseEntity<ApiResponse<List<ReadJoinTeamRequestResponse>>> readJoinTeamRequest(@AuthenticationPrincipal User user, @RequestParam Long teamId) {
+        List<ServiceReadJoinTeamRequestResponse> serviceResponseList = teamService.readJoinTeamRequest(user, teamId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.ok(toReadJoinTeamRequestResponseList(serviceResponseList), "가입 요청 목록 조회 완료"));
+    }
+
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/request/CreateTeamRequest.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/request/CreateTeamRequest.java
@@ -1,0 +1,14 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.controller.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class CreateTeamRequest {
+    private final String name;
+    private final String introduce;
+    private final String infoImageUrl;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/request/JoinTeamRequestRequest.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/request/JoinTeamRequestRequest.java
@@ -1,0 +1,13 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.controller.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class JoinTeamRequestRequest {
+    private final Long teamId;
+    private final String joinIntroduce;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/request/RespondJoinTeamRequest.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/request/RespondJoinTeamRequest.java
@@ -1,0 +1,13 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.controller.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class RespondJoinTeamRequest {
+    private final Long teamUsersId;
+    private final boolean accepted;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/request/UpdateTeamRequest.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/request/UpdateTeamRequest.java
@@ -1,0 +1,14 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.controller.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class UpdateTeamRequest {
+    private final Long teamId;
+    private final String introduce;
+    private final String infoImageUrl;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/response/CreateTeamResponse.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/response/CreateTeamResponse.java
@@ -1,0 +1,14 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.controller.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class CreateTeamResponse {
+    private final String name;
+    private final String introduce;
+    private final String infoImageUrl;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/response/JoinTeamRequestResponse.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/response/JoinTeamRequestResponse.java
@@ -1,0 +1,13 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.controller.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class JoinTeamRequestResponse {
+    private final String teamName;
+    private final String joinStatusDescription;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/response/ReadJoinTeamRequestResponse.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/response/ReadJoinTeamRequestResponse.java
@@ -1,0 +1,16 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.controller.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class ReadJoinTeamRequestResponse {
+    private final Long userId;
+    private final String nickname;
+    private final String joinIntroduce;
+    private final String profileImageUrl;
+    private final String joinStatusDescription;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/response/ReadTeamResponse.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/response/ReadTeamResponse.java
@@ -1,0 +1,18 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.controller.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class ReadTeamResponse {
+    private final String name;
+    private final String infoImageURL;
+    private final String introduce;
+    private final int teamMemberCount;
+    private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/response/UpdateTeamResponse.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/controller/response/UpdateTeamResponse.java
@@ -1,0 +1,18 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.controller.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class UpdateTeamResponse {
+    private final Long teamId;
+    private final String name;
+    private final String introduce;
+    private final String infoImageUrl;
+    private final LocalDateTime updatedAt;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/request/ServiceCreateTeamRequest.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/request/ServiceCreateTeamRequest.java
@@ -1,0 +1,14 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.service.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class ServiceCreateTeamRequest {
+    private final String name;
+    private final String introduce;
+    private final String infoImageUrl;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/request/ServiceJoinTeamRequestRequest.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/request/ServiceJoinTeamRequestRequest.java
@@ -1,0 +1,13 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.service.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class ServiceJoinTeamRequestRequest {
+    private final Long teamId;
+    private final String joinIntroduce;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/request/ServiceReadTeamResponse.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/request/ServiceReadTeamResponse.java
@@ -1,0 +1,18 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.service.request;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class ServiceReadTeamResponse {
+    private final String name;
+    private final String infoImageURL;
+    private final String introduce;
+    private final int teamMemberCount;
+    private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/request/ServiceUpdateTeamRequest.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/request/ServiceUpdateTeamRequest.java
@@ -1,0 +1,14 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.service.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class ServiceUpdateTeamRequest {
+    private final Long teamId;
+    private final String introduce;
+    private final String infoImageUrl;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/response/ServiceCreateTeamResponse.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/response/ServiceCreateTeamResponse.java
@@ -1,0 +1,14 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.service.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class ServiceCreateTeamResponse {
+    private final String name;
+    private final String introduce;
+    private final String infoImageUrl;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/response/ServiceJoinTeamRequestResponse.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/response/ServiceJoinTeamRequestResponse.java
@@ -1,0 +1,13 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.service.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class ServiceJoinTeamRequestResponse {
+    private final String teamName;
+    private final String joinStatusDescription;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/response/ServiceReadJoinTeamRequestResponse.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/response/ServiceReadJoinTeamRequestResponse.java
@@ -1,0 +1,16 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.service.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class ServiceReadJoinTeamRequestResponse {
+    private final Long userId;
+    private final String nickname;
+    private final String joinIntroduce;
+    private final String profileImageUrl;
+    private final String joinStatusDescription;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/response/ServiceUpdateTeamResponse.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/dto/service/response/ServiceUpdateTeamResponse.java
@@ -1,0 +1,18 @@
+package com.wccg.well_c_code_git_backend.domain.team.dto.service.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+public class ServiceUpdateTeamResponse {
+    private final Long teamId;
+    private final String name;
+    private final String introduce;
+    private final String infoImageUrl;
+    private final LocalDateTime updatedAt;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/mapper/TeamMapper.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/mapper/TeamMapper.java
@@ -5,8 +5,10 @@ import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.JoinT
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.JoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadJoinTeamRequestResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceCreateTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceJoinTeamRequestRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceReadTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceReadJoinTeamRequestResponse;
@@ -87,5 +89,25 @@ public final class TeamMapper {
                         serviceResponse.getJoinStatusDescription()
                 ))
                 .toList();
+    }
+
+    public static ServiceReadTeamResponse toServiceReadTeamResponse(Team team, int teamMemberCount){
+        return new ServiceReadTeamResponse(
+                team.getName(),
+                team.getIntroduce(),
+                team.getInfoImageUrl(),
+                teamMemberCount,
+                team.getCreatedAt()
+        );
+    }
+
+    public static ReadTeamResponse toReadTeamResponse(ServiceReadTeamResponse serviceReadTeamResponse){
+        return new ReadTeamResponse(
+                serviceReadTeamResponse.getName(),
+                serviceReadTeamResponse.getIntroduce(),
+                serviceReadTeamResponse.getInfoImageURL(),
+                serviceReadTeamResponse.getTeamMemberCount(),
+                serviceReadTeamResponse.getCreatedAt()
+        );
     }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/mapper/TeamMapper.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/mapper/TeamMapper.java
@@ -1,0 +1,37 @@
+package com.wccg.well_c_code_git_backend.domain.team.mapper;
+
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.CreateTeamRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceCreateTeamRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.model.Team;
+
+public final class TeamMapper {
+    private TeamMapper(){
+
+    }
+
+    public static ServiceCreateTeamRequest toServiceCreateTeamRequest(CreateTeamRequest request){
+        return new ServiceCreateTeamRequest(
+                request.getName(),
+                request.getIntroduce(),
+                request.getInfoImageUrl()
+        );
+    }
+
+    public static ServiceCreateTeamResponse toServiceCreateTeamResponse(Team team){
+        return new ServiceCreateTeamResponse(
+                team.getName(),
+                team.getIntroduce(),
+                team.getInfoImageUrl()
+        );
+    }
+
+    public static CreateTeamResponse toCreateTeamResponse(ServiceCreateTeamResponse serviceResponse){
+        return new CreateTeamResponse(
+                serviceResponse.getName(),
+                serviceResponse.getIntroduce(),
+                serviceResponse.getInfoImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/mapper/TeamMapper.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/mapper/TeamMapper.java
@@ -4,12 +4,18 @@ import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.Creat
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.JoinTeamRequestRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.JoinTeamRequestResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceCreateTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceJoinTeamRequestRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceJoinTeamRequestResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceReadJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.model.Team;
 import com.wccg.well_c_code_git_backend.domain.team.model.TeamUsers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public final class TeamMapper {
     private TeamMapper(){
@@ -59,5 +65,27 @@ public final class TeamMapper {
                 serviceResponse.getTeamName(),
                 serviceResponse.getJoinStatusDescription()
         );
+    }
+
+    public static ServiceReadJoinTeamRequestResponse toServiceReadJoinTeamRequestResponse(TeamUsers teamUsers){
+        return new ServiceReadJoinTeamRequestResponse(
+                teamUsers.getUser().getId(),
+                teamUsers.getUser().getNickname(),
+                teamUsers.getJoinIntroduce(),
+                teamUsers.getUser().getProfileImageUrl(),
+                teamUsers.getJoinStatus().getDescription()
+        );
+    }
+
+    public static List<ReadJoinTeamRequestResponse> toReadJoinTeamRequestResponseList(List<ServiceReadJoinTeamRequestResponse> serviceResponselist) {
+        return serviceResponselist.stream()
+                .map(serviceResponse -> new ReadJoinTeamRequestResponse(
+                        serviceResponse.getUserId(),
+                        serviceResponse.getNickname(),
+                        serviceResponse.getJoinIntroduce(),
+                        serviceResponse.getProfileImageUrl(),
+                        serviceResponse.getJoinStatusDescription()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/mapper/TeamMapper.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/mapper/TeamMapper.java
@@ -1,10 +1,15 @@
 package com.wccg.well_c_code_git_backend.domain.team.mapper;
 
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.CreateTeamRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.JoinTeamRequestRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.JoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceCreateTeamRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceJoinTeamRequestRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.model.Team;
+import com.wccg.well_c_code_git_backend.domain.team.model.TeamUsers;
 
 public final class TeamMapper {
     private TeamMapper(){
@@ -32,6 +37,27 @@ public final class TeamMapper {
                 serviceResponse.getName(),
                 serviceResponse.getIntroduce(),
                 serviceResponse.getInfoImageUrl()
+        );
+    }
+
+    public static ServiceJoinTeamRequestRequest toServiceJoinTeamRequestRequest(JoinTeamRequestRequest request){
+        return new ServiceJoinTeamRequestRequest(
+                request.getTeamId(),
+                request.getJoinIntroduce()
+        );
+    }
+
+    public static ServiceJoinTeamRequestResponse toServiceJoinTeamRequestResponse(TeamUsers teamUsers){
+        return new ServiceJoinTeamRequestResponse(
+                teamUsers.getTeam().getName(),
+                teamUsers.getJoinStatus().getDescription()
+        );
+    }
+
+    public static JoinTeamRequestResponse toJoinTeamRequestResponse(ServiceJoinTeamRequestResponse serviceResponse){
+        return new JoinTeamRequestResponse(
+                serviceResponse.getTeamName(),
+                serviceResponse.getJoinStatusDescription()
         );
     }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/mapper/TeamMapper.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/mapper/TeamMapper.java
@@ -2,16 +2,16 @@ package com.wccg.well_c_code_git_backend.domain.team.mapper;
 
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.CreateTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.JoinTeamRequestRequest;
-import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.CreateTeamResponse;
-import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.JoinTeamRequestResponse;
-import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadJoinTeamRequestResponse;
-import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.ReadTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.UpdateTeamRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.response.*;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceCreateTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceJoinTeamRequestRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceReadTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceUpdateTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceReadJoinTeamRequestResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceUpdateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.model.Team;
 import com.wccg.well_c_code_git_backend.domain.team.model.TeamUsers;
 
@@ -108,6 +108,34 @@ public final class TeamMapper {
                 serviceReadTeamResponse.getInfoImageURL(),
                 serviceReadTeamResponse.getTeamMemberCount(),
                 serviceReadTeamResponse.getCreatedAt()
+        );
+    }
+
+    public static ServiceUpdateTeamRequest toServiceUpdateTeamRequest(UpdateTeamRequest request){
+        return new ServiceUpdateTeamRequest(
+                request.getTeamId(),
+                request.getIntroduce(),
+                request.getInfoImageUrl()
+        );
+    }
+
+    public static ServiceUpdateTeamResponse toServiceUpdateTeamResponse(Team team){
+        return new ServiceUpdateTeamResponse(
+                team.getId(),
+                team.getName(),
+                team.getIntroduce(),
+                team.getInfoImageUrl(),
+                team.getUpdatedAt()
+        );
+    }
+
+    public static UpdateTeamResponse toUpdateTeamResponse(ServiceUpdateTeamResponse serviceResponse){
+        return new UpdateTeamResponse(
+                serviceResponse.getTeamId(),
+                serviceResponse.getName(),
+                serviceResponse.getIntroduce(),
+                serviceResponse.getInfoImageUrl(),
+                serviceResponse.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/JoinStatus.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/JoinStatus.java
@@ -1,8 +1,10 @@
 package com.wccg.well_c_code_git_backend.domain.team.model;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum JoinStatus {
     PENDING("대기중"),
     ACCEPTED("수락"),

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/JoinStatus.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/JoinStatus.java
@@ -1,0 +1,12 @@
+package com.wccg.well_c_code_git_backend.domain.team.model;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum JoinStatus {
+    PENDING("대기중"),
+    ACCEPTED("수락"),
+    REJECTED("거절");
+
+    private final String description;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/Team.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/Team.java
@@ -61,4 +61,9 @@ public class Team extends BaseEntity {
                 .isActive(isActive)
                 .build();
     }
+
+    public void updateTeamInfo(String introduce,String infoImageUrl){
+        this.introduce = introduce;
+        this.infoImageUrl = infoImageUrl;
+    }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/Team.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/Team.java
@@ -1,5 +1,6 @@
 package com.wccg.well_c_code_git_backend.domain.team.model;
 
+import com.wccg.well_c_code_git_backend.domain.BaseEntity;
 import com.wccg.well_c_code_git_backend.domain.user.model.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,7 +14,7 @@ import java.util.List;
 @Table(indexes = {
 //        @Index(columnList = "name, is_active")
 })
-public class Team {
+public class Team extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/Team.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/Team.java
@@ -1,0 +1,63 @@
+package com.wccg.well_c_code_git_backend.domain.team.model;
+
+import com.wccg.well_c_code_git_backend.domain.user.model.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = {
+//        @Index(columnList = "name, is_active")
+})
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 12)
+    private String name;
+
+    @Column(name = "introduce", nullable = false, length = 200)
+    private String introduce;
+
+    @Column(name = "info_image_url", nullable = false, length = 200)
+    private String infoImageUrl;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<TeamUsers> teamUsers = new ArrayList<>();
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "leader_id", nullable = false)
+    private User leader;
+
+    public void addTeamUser(TeamUsers teamUser){
+        teamUsers.add(teamUser);
+        teamUser.setTeam(this);
+    }
+
+    @Builder
+    private Team(String name, String introduce, String infoImageUrl, boolean isActive) {
+        this.name = name;
+        this.introduce = introduce;
+        this.infoImageUrl = infoImageUrl;
+        this.isActive = isActive;
+    }
+
+    public static Team of(String name, String introduce, String infoImageUrl, boolean isActive){
+        return Team.builder()
+                .name(name)
+                .introduce(introduce)
+                .infoImageUrl(infoImageUrl)
+                .isActive(isActive)
+                .build();
+    }
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/TeamUsers.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/TeamUsers.java
@@ -1,0 +1,41 @@
+package com.wccg.well_c_code_git_backend.domain.team.model;
+
+import com.wccg.well_c_code_git_backend.domain.user.model.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = {
+        @Index(columnList = "team_id, is_active")
+})
+public class TeamUsers {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "join_status", nullable = false)
+    private JoinStatus joinStatus;
+
+    @Column(name = "join_introduce", nullable = false, length = 200)
+    private String joinIntroduce;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/TeamUsers.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/TeamUsers.java
@@ -2,10 +2,7 @@ package com.wccg.well_c_code_git_backend.domain.team.model;
 
 import com.wccg.well_c_code_git_backend.domain.user.model.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
@@ -38,4 +35,19 @@ public class TeamUsers {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;
+
+    @Builder
+    private TeamUsers(JoinStatus joinStatus, String joinIntroduce, boolean isActive) {
+        this.joinStatus = joinStatus;
+        this.joinIntroduce = joinIntroduce;
+        this.isActive = isActive;
+    }
+
+    public static TeamUsers of(JoinStatus joinStatus, String joinIntroduce, boolean isActive){
+        return TeamUsers.builder()
+                .joinStatus(joinStatus)
+                .joinIntroduce(joinIntroduce)
+                .isActive(isActive)
+                .build();
+    }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/TeamUsers.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/TeamUsers.java
@@ -2,6 +2,7 @@ package com.wccg.well_c_code_git_backend.domain.team.model;
 
 import com.wccg.well_c_code_git_backend.domain.BaseEntity;
 import com.wccg.well_c_code_git_backend.domain.user.model.User;
+import com.wccg.well_c_code_git_backend.global.exception.exceptions.TeamJoinRequestInvalidStatusException;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -51,5 +52,17 @@ public class TeamUsers extends BaseEntity {
                 .joinIntroduce(joinIntroduce)
                 .isActive(isActive)
                 .build();
+    }
+
+    public TeamUsers approveJoinRequest(boolean isApproved) {
+        if (this.joinStatus != JoinStatus.PENDING) {
+            throw new TeamJoinRequestInvalidStatusException();
+        }
+        if(isApproved){
+            this.joinStatus = JoinStatus.ACCEPTED;
+            return this;
+        }
+        this.joinStatus = JoinStatus.REJECTED;
+        return this;
     }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/TeamUsers.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/model/TeamUsers.java
@@ -1,5 +1,6 @@
 package com.wccg.well_c_code_git_backend.domain.team.model;
 
+import com.wccg.well_c_code_git_backend.domain.BaseEntity;
 import com.wccg.well_c_code_git_backend.domain.user.model.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -8,9 +9,10 @@ import lombok.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = {
-        @Index(columnList = "team_id, is_active")
+        @Index(columnList = "team_id, is_active"),
+        @Index(columnList = "team_id, is_active, created_at")
 })
-public class TeamUsers {
+public class TeamUsers extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/repository/TeamRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByName(String name);
+
+    Optional<Team> findByIdAndIsActiveTrue(Long teamId);
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/repository/TeamRepository.java
@@ -1,0 +1,10 @@
+package com.wccg.well_c_code_git_backend.domain.team.repository;
+
+import com.wccg.well_c_code_git_backend.domain.team.model.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+    Optional<Team> findByName(String name);
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/repository/TeamUsersRepository.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/repository/TeamUsersRepository.java
@@ -1,10 +1,14 @@
 package com.wccg.well_c_code_git_backend.domain.team.repository;
 
+import com.wccg.well_c_code_git_backend.domain.team.model.JoinStatus;
 import com.wccg.well_c_code_git_backend.domain.team.model.TeamUsers;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TeamUsersRepository extends JpaRepository<TeamUsers,Long> {
     List<TeamUsers> findAllByTeamIdAndIsActiveTrueOrderByCreatedAtDesc(Long teamId);
+
+    List<TeamUsers> findAllByTeamIdAndJoinStatusAndIsActiveTrue(Long teamId, JoinStatus joinStatus);
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/repository/TeamUsersRepository.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/repository/TeamUsersRepository.java
@@ -3,5 +3,8 @@ package com.wccg.well_c_code_git_backend.domain.team.repository;
 import com.wccg.well_c_code_git_backend.domain.team.model.TeamUsers;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TeamUsersRepository extends JpaRepository<TeamUsers,Long> {
+    List<TeamUsers> findAllByTeamIdAndIsActiveTrueOrderByCreatedAtDesc(Long teamId);
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/repository/TeamUsersRepository.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/repository/TeamUsersRepository.java
@@ -1,0 +1,7 @@
+package com.wccg.well_c_code_git_backend.domain.team.repository;
+
+import com.wccg.well_c_code_git_backend.domain.team.model.TeamUsers;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamUsersRepository extends JpaRepository<TeamUsers,Long> {
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/service/TeamService.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/service/TeamService.java
@@ -1,0 +1,82 @@
+package com.wccg.well_c_code_git_backend.domain.team.service;
+
+import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.CreateTeamRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.model.JoinStatus;
+import com.wccg.well_c_code_git_backend.domain.team.model.Team;
+import com.wccg.well_c_code_git_backend.domain.team.model.TeamUsers;
+import com.wccg.well_c_code_git_backend.domain.team.repository.TeamRepository;
+import com.wccg.well_c_code_git_backend.domain.team.repository.TeamUsersRepository;
+import com.wccg.well_c_code_git_backend.domain.user.model.User;
+import com.wccg.well_c_code_git_backend.global.exception.exceptions.TeamNameConflictException;
+import com.wccg.well_c_code_git_backend.global.exception.exceptions.TeamNameLengthInvalidException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.wccg.well_c_code_git_backend.domain.team.mapper.TeamMapper.toServiceCreateTeamResponse;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final TeamUsersRepository teamUsersRepository;
+
+    public ServiceCreateTeamResponse createTeam(User user, CreateTeamRequest request) {
+        String teamName = request.getName();
+        teamNameValidate(teamName);
+
+        Team newTeam = buildTeamFromRequest(request,user);
+        teamRepository.save(newTeam);
+
+        createTeamUsersRelationFromTeamLeader(newTeam);
+
+        return toServiceCreateTeamResponse(newTeam);
+    }
+
+    private void createTeamUsersRelationFromTeamLeader(Team newTeam) {
+        TeamUsers teamUsers = buildTeamUsersFromTeamLeader(newTeam);
+        teamUsersRepository.save(teamUsers);
+    }
+
+    private TeamUsers buildTeamUsersFromTeamLeader(Team newTeam) {
+        TeamUsers teamUsers = TeamUsers.of(
+                JoinStatus.ACCEPTED,
+                "이 팀을 최초로 생성했어요.",
+                true
+        );
+        teamUsers.setTeam(newTeam);
+        teamUsers.setUser(newTeam.getLeader());
+        return teamUsers;
+    }
+
+    private Team buildTeamFromRequest(CreateTeamRequest request,User user) {
+        Team team = Team.of(
+                request.getName(),
+                request.getIntroduce(),
+                request.getInfoImageUrl(),
+                true
+        );
+        team.setLeader(user);
+        return team;
+    }
+
+    private void teamNameValidate(String teamName) {
+        teamNameLengthValidate(teamName);
+        teamNameConflictValidate(teamName);
+    }
+
+    private void teamNameLengthValidate(String teamName) {
+        if(teamName.length() < 2 || teamName.length() > 12){
+            throw new TeamNameLengthInvalidException();
+        }
+    }
+
+    private void teamNameConflictValidate(String teamName) {
+        if (teamRepository.findByName(teamName).isPresent()) {
+            throw new TeamNameConflictException();
+        }
+    }
+
+
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/service/TeamService.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/service/TeamService.java
@@ -3,6 +3,7 @@ package com.wccg.well_c_code_git_backend.domain.team.service;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.CreateTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.RespondJoinTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceJoinTeamRequestRequest;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceReadTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceReadJoinTeamRequestResponse;
@@ -155,5 +156,16 @@ public class TeamService {
     private TeamUsers teamUsersNotFoundValidate(RespondJoinTeamRequest request) {
         return teamUsersRepository.findById(request.getTeamUsersId())
                 .orElseThrow(TeamJoinRequestNotFound::new);
+    }
+
+    public ServiceReadTeamResponse readTeam(Long teamId) {
+        int teamMemberCount = getTeamMemberCount(teamId);
+        Team team = teamNotFoundValidate(teamId);
+        return toServiceReadTeamResponse(team,teamMemberCount);
+    }
+
+    private int getTeamMemberCount(Long teamId) {
+        List<TeamUsers> teamUsersList = teamUsersRepository.findAllByTeamIdAndJoinStatusAndIsActiveTrue(teamId, JoinStatus.ACCEPTED);
+        return teamUsersList.size();
     }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/team/service/TeamService.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/team/service/TeamService.java
@@ -4,9 +4,11 @@ import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.Creat
 import com.wccg.well_c_code_git_backend.domain.team.dto.controller.request.RespondJoinTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceJoinTeamRequestRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceReadTeamResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.request.ServiceUpdateTeamRequest;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceCreateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceJoinTeamRequestResponse;
 import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceReadJoinTeamRequestResponse;
+import com.wccg.well_c_code_git_backend.domain.team.dto.service.response.ServiceUpdateTeamResponse;
 import com.wccg.well_c_code_git_backend.domain.team.mapper.TeamMapper;
 import com.wccg.well_c_code_git_backend.domain.team.model.JoinStatus;
 import com.wccg.well_c_code_git_backend.domain.team.model.Team;
@@ -167,5 +169,19 @@ public class TeamService {
     private int getTeamMemberCount(Long teamId) {
         List<TeamUsers> teamUsersList = teamUsersRepository.findAllByTeamIdAndJoinStatusAndIsActiveTrue(teamId, JoinStatus.ACCEPTED);
         return teamUsersList.size();
+    }
+
+    public ServiceUpdateTeamResponse updateTeam(User user, ServiceUpdateTeamRequest serviceRequest) {
+        Team team = teamNotFoundValidate(serviceRequest.getTeamId());
+        teamLeaderValidate(user, team);
+
+        String introduce = serviceRequest.getIntroduce();
+        String infoImageUrl = serviceRequest.getInfoImageUrl();
+
+        team.updateTeamInfo(introduce,infoImageUrl);
+
+        teamRepository.save(team);
+
+        return toServiceUpdateTeamResponse(team);
     }
 }

--- a/src/main/java/com/wccg/well_c_code_git_backend/domain/user/model/User.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/domain/user/model/User.java
@@ -3,6 +3,8 @@ package com.wccg.well_c_code_git_backend.domain.user.model;
 import com.wccg.well_c_code_git_backend.domain.BaseEntity;
 import com.wccg.well_c_code_git_backend.domain.accesstoken.model.AccessToken;
 import com.wccg.well_c_code_git_backend.domain.commit.model.Commit;
+import com.wccg.well_c_code_git_backend.domain.team.model.Team;
+import com.wccg.well_c_code_git_backend.domain.team.model.TeamUsers;
 import com.wccg.well_c_code_git_backend.domain.wccgrepository.model.WccgRepository;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -62,6 +64,12 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Commit> commits = new ArrayList<>();
 
+    @OneToMany(mappedBy = "leader", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Team> teams = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<TeamUsers> teamUsers = new ArrayList<>();
+
     @Builder
     private User(Long githubId, String githubLoginId, String name, String nickname, String introduce, String profileImageUrl, UserRole userRole, boolean isActive) {
         this.githubId = githubId;
@@ -100,6 +108,16 @@ public class User extends BaseEntity {
     public void addCommit(Commit commit) {
         commits.add(commit);
         commit.setUser(this);
+    }
+
+    public void addTeam(Team team){
+        teams.add(team);
+        team.setLeader(this);
+    }
+
+    public void addTeamUser(TeamUsers teamUser){
+        teamUsers.add(teamUser);
+        teamUser.setUser(this);
     }
 
     public void updateProfile(String nickname, String introduce, String profileImageUrl) {

--- a/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamApplicantForbiddenException.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamApplicantForbiddenException.java
@@ -1,0 +1,10 @@
+package com.wccg.well_c_code_git_backend.global.exception.exceptions;
+
+import com.wccg.well_c_code_git_backend.global.exception.model.BaseException;
+import com.wccg.well_c_code_git_backend.global.exception.model.ErrorCode;
+
+public class TeamApplicantForbiddenException extends BaseException {
+    public TeamApplicantForbiddenException() {
+        super(ErrorCode.TEAM_APPLICANT_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamJoinRequestInvalidStatusException.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamJoinRequestInvalidStatusException.java
@@ -1,0 +1,10 @@
+package com.wccg.well_c_code_git_backend.global.exception.exceptions;
+
+import com.wccg.well_c_code_git_backend.global.exception.model.BaseException;
+import com.wccg.well_c_code_git_backend.global.exception.model.ErrorCode;
+
+public class TeamJoinRequestInvalidStatusException extends BaseException {
+    public TeamJoinRequestInvalidStatusException() {
+        super(ErrorCode.TEAM_JOIN_REQUEST_INVALID_STATUS);
+    }
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamJoinRequestNotFound.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamJoinRequestNotFound.java
@@ -1,0 +1,10 @@
+package com.wccg.well_c_code_git_backend.global.exception.exceptions;
+
+import com.wccg.well_c_code_git_backend.global.exception.model.BaseException;
+import com.wccg.well_c_code_git_backend.global.exception.model.ErrorCode;
+
+public class TeamJoinRequestNotFound extends BaseException {
+    public TeamJoinRequestNotFound() {
+        super(ErrorCode.TEAM_JOIN_REQUEST_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamNameConflictException.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamNameConflictException.java
@@ -1,0 +1,10 @@
+package com.wccg.well_c_code_git_backend.global.exception.exceptions;
+
+import com.wccg.well_c_code_git_backend.global.exception.model.BaseException;
+import com.wccg.well_c_code_git_backend.global.exception.model.ErrorCode;
+
+public class TeamNameConflictException extends BaseException {
+    public TeamNameConflictException() {
+        super(ErrorCode.TEAM_NAME_CONFLICT);
+    }
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamNameLengthInvalidException.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamNameLengthInvalidException.java
@@ -1,0 +1,10 @@
+package com.wccg.well_c_code_git_backend.global.exception.exceptions;
+
+import com.wccg.well_c_code_git_backend.global.exception.model.BaseException;
+import com.wccg.well_c_code_git_backend.global.exception.model.ErrorCode;
+
+public class TeamNameLengthInvalidException extends BaseException {
+    public TeamNameLengthInvalidException() {
+        super(ErrorCode.TEAM_NAME_LENGTH_INVALID);
+    }
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamNotFoundException.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/global/exception/exceptions/TeamNotFoundException.java
@@ -1,0 +1,10 @@
+package com.wccg.well_c_code_git_backend.global.exception.exceptions;
+
+import com.wccg.well_c_code_git_backend.global.exception.model.BaseException;
+import com.wccg.well_c_code_git_backend.global.exception.model.ErrorCode;
+
+public class TeamNotFoundException extends BaseException {
+    public TeamNotFoundException() {
+        super(ErrorCode.TEAM_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/wccg/well_c_code_git_backend/global/exception/model/ErrorCode.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/global/exception/model/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     TEAM_NAME_CONFLICT(HttpStatus.CONFLICT,"E012","중복된 팀 이름 입니다."),
     TEAM_NAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "E013", "팀 이름은 2글자 이상 12글자 이하만 가능합니다."),
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "E014", "해당 팀을 찾을 수 없습니다."),
+    TEAM_APPLICANT_FORBIDDEN(HttpStatus.FORBIDDEN, "E015", "해당 팀의 신청 목록을 조회할 권한이 없습니다."),
     FOR_TEST_ERROR(HttpStatus.BAD_REQUEST, "E777", "테스트용 에러 코드");
 
     private final HttpStatus status;

--- a/src/main/java/com/wccg/well_c_code_git_backend/global/exception/model/ErrorCode.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/global/exception/model/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
     TEAM_NAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "E013", "팀 이름은 2글자 이상 12글자 이하만 가능합니다."),
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "E014", "해당 팀을 찾을 수 없습니다."),
     TEAM_APPLICANT_FORBIDDEN(HttpStatus.FORBIDDEN, "E015", "해당 팀의 신청 목록을 조회할 권한이 없습니다."),
+    TEAM_JOIN_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "E016", "해당 팀 가입 요청을 찾을 수 없습니다."),
+    TEAM_JOIN_REQUEST_INVALID_STATUS(HttpStatus.BAD_REQUEST, "E017", "가입 신청은 대기중 상태 에서만 처리할 수 있습니다."),
     FOR_TEST_ERROR(HttpStatus.BAD_REQUEST, "E777", "테스트용 에러 코드");
 
     private final HttpStatus status;

--- a/src/main/java/com/wccg/well_c_code_git_backend/global/exception/model/ErrorCode.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/global/exception/model/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     INTRODUCE_TOO_LONG(HttpStatus.BAD_REQUEST, "E011", "자기소개는 200자를 초과할 수 없습니다."),
     TEAM_NAME_CONFLICT(HttpStatus.CONFLICT,"E012","중복된 팀 이름 입니다."),
     TEAM_NAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "E013", "팀 이름은 2글자 이상 12글자 이하만 가능합니다."),
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "E014", "해당 팀을 찾을 수 없습니다."),
     FOR_TEST_ERROR(HttpStatus.BAD_REQUEST, "E777", "테스트용 에러 코드");
 
     private final HttpStatus status;

--- a/src/main/java/com/wccg/well_c_code_git_backend/global/exception/model/ErrorCode.java
+++ b/src/main/java/com/wccg/well_c_code_git_backend/global/exception/model/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
     IMAGE_TOO_LARGE(HttpStatus.BAD_REQUEST, "E009", "파일 크기가 15MB를 초과했습니다."),
     INVALID_IMAGE_DIMENSIONS(HttpStatus.BAD_REQUEST, "E010", "이미지 크기는 반드시 100*100 이어야 합니다."),
     INTRODUCE_TOO_LONG(HttpStatus.BAD_REQUEST, "E011", "자기소개는 200자를 초과할 수 없습니다."),
+    TEAM_NAME_CONFLICT(HttpStatus.CONFLICT,"E012","중복된 팀 이름 입니다."),
+    TEAM_NAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "E013", "팀 이름은 2글자 이상 12글자 이하만 가능합니다."),
     FOR_TEST_ERROR(HttpStatus.BAD_REQUEST, "E777", "테스트용 에러 코드");
 
     private final HttpStatus status;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,8 @@ jwt.exclude-paths=\
 /api/wccgrepository/repositories,\
 /api/status,\
 /api/user/nickname/available,\
-/api/user/profile
+/api/user/profile,\
+/api/team
 
 # log
 # 전체 로그 레벨


### PR DESCRIPTION
- 팀 생성
- 팀 가입 요청
  - 팀 관리자의 팀 가입 요청 조회
  - 팀 가입 요청 수락/거절
- 팀 정보 조회(깃허브 스탯 제외)
  - 팀 이름
  - 팀 인원 수
  - 팀 정보 사진
  - 팀 소개문구
  - 팀 생성일
- 팀 수정
  - 팀 정보 사진
  - 팀 소개문구

***
다음 팀 개발시 구현해야 할 기능
- 팀 삭제
- 팀 탈퇴
- 팀원 추방
- 팀원 목록 조회
- 팀 조회 상세(깃허브 스탯)
  - 팀의 커밋 스탯
    - 팀 전체 오늘 커밋 횟수
    - 팀 전체 주간 커밋 횟수
    - 팀 전체 모든기간 커밋 횟수
   - 팀의 최근 커밋 목록

아래는 유저 관련 개발시 구현해야 할 기능
- 내가 신청한 팀 목록 조회
- 내가 소속한 팀 목록의 간단한 정보 조회